### PR TITLE
Fix left right orientation of MNI data

### DIFF
--- a/datasets/ABIDE/README.md
+++ b/datasets/ABIDE/README.md
@@ -69,7 +69,7 @@ The output table of curated subjects with phenotypic labels is in [`metadata/ABI
 Finally, generate output Arrow datasets for all target standard spaces
 
 ```bash
-uv run python scripts/make_abide_dataset.py --space schaefer400
+uv run python scripts/make_abide_arrow.py --space schaefer400
 ```
 
 The script standardizes all runs to TR = 2.0s across sites, and selects the first 150 TRs (5 min) for each included run.

--- a/datasets/ABIDE/scripts/make_abide_arrow.py
+++ b/datasets/ABIDE/scripts/make_abide_arrow.py
@@ -3,15 +3,17 @@ import json
 import logging
 import sys
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import datasets as hfds
 import numpy as np
 import pandas as pd
-from cloudpathlib import AnyPath
+from cloudpathlib import AnyPath, CloudPath, S3Path
 
 import fmri_fm_eval.nisc as nisc
 import fmri_fm_eval.readers as readers
+import fmri_fm_eval.utils as ut
 
 logging.basicConfig(
     format="[%(levelname)s %(asctime)s]: %(message)s",
@@ -19,6 +21,7 @@ logging.basicConfig(
     datefmt="%y-%m-%d %H:%M:%S",
 )
 logging.getLogger("nibabel").setLevel(logging.ERROR)
+logging.getLogger("botocore").setLevel(logging.ERROR)  # quiet aws credential log msg
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +36,8 @@ MAX_NUM_TRS = 150
 
 
 def main(args):
-    outdir = ROOT / f"data/processed/abide.{args.space}.arrow"
+    out_root = AnyPath(args.out_root or (ROOT / "data/processed"))
+    outdir = out_root / f"abide.{args.space}.arrow"
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
         _logger.warning("Output %s exists; exiting.", outdir)
@@ -50,16 +54,14 @@ def main(args):
         suffix = "_space-fsLR_den-91k_bold.dtseries.nii"
 
     # preprocessed data paths
-    fmriprep_root = ROOT / "data/fmriprep"
-    curated_paths = [fmriprep_root / p.replace("_bold.nii.gz", suffix) for p in curated_paths]
-    assert all(p.exists() for p in curated_paths)
+    curated_paths = [p.replace("_bold.nii.gz", suffix) for p in curated_paths]
 
     # mapping of subs to assigned splits
     sub_split_map = {sub: split for sub, split in zip(curated_df["sub"], curated_df["split"])}
     # data paths for each split
     path_splits = {split: [] for split in SPLITS}
     for path in curated_paths:
-        sub = path.parts[-3].split("-")[1]
+        sub = path.split("/")[1].split("-")[1]
         split = sub_split_map[sub]
         path_splits[split].append(path)
 
@@ -67,6 +69,9 @@ def main(args):
     # all readers return a bold data array of shape (n_samples, dim).
     reader = readers.READER_DICT[args.space]()
     dim = readers.DATA_DIMS[args.space]
+
+    # root can be local or remote.
+    root = AnyPath(args.root or ROOT / "data/fmriprep")
 
     # the bold data are scaled to mean 0, stdev 1 and then truncated to float16 to save
     # space. but we keep the mean and std to reverse this since some models need this.
@@ -91,40 +96,48 @@ def main(args):
             dataset_dict[split] = hfds.Dataset.from_generator(
                 generate_samples,
                 features=features,
-                gen_kwargs={"paths": paths, "root": fmriprep_root, "reader": reader, "dim": dim},
+                gen_kwargs={"paths": paths, "root": root, "reader": reader},
                 num_proc=args.num_proc,
                 split=hfds.NamedSplit(split),
                 cache_dir=tmpdir,
+                # otherwise fingerprint crashes on mni space
+                fingerprint=f"abide-{args.space}-{split}",
             )
         dataset = hfds.DatasetDict(dataset_dict)
 
-        outdir.parent.mkdir(exist_ok=True, parents=True)
-        dataset.save_to_disk(outdir, max_shard_size="300MB")
+        if isinstance(outdir, S3Path):
+            _logger.info("Saving to s3: %s", outdir)
+            tmp_outdir = Path(tmpdir) / outdir.name
+            # in theory save_to_disk should support s3, but idk why it wasn't working
+            dataset.save_to_disk(tmp_outdir, max_shard_size="300MB")
+            ut.rsync(tmp_outdir, outdir)
+        else:
+            _logger.info("Saving locally: %s", outdir)
+            dataset.save_to_disk(outdir, max_shard_size="300MB")
 
 
-def generate_samples(paths: list[Path], *, root: AnyPath, reader: readers.Reader, dim: int):
-    for path in paths:
-        sidecar_path = path.parent / (path.name.split(".")[0] + ".json")
+def generate_samples(paths: list[Path], *, root: AnyPath, reader: readers.Reader):
+    for path, fullpath in prefetch(root, paths):
+        sidecar_path = fullpath.parent / (fullpath.name.split(".")[0] + ".json")
         with sidecar_path.open() as f:
             sidecar_data = json.load(f)
         tr = float(sidecar_data["RepetitionTime"])
         meta = parse_abide_metadata(path)
 
-        series = reader(path)
+        series = reader(fullpath)
         series = nisc.resample_timeseries(series, tr=tr, new_tr=TARGET_TR, kind="pchip")
 
         T, D = series.shape
-        assert D == dim
-        if T < MAX_NUM_TRS:
-            _logger.warning(f"Path {path} does not have enough data ({T}<{MAX_NUM_TRS}); skipping.")
-            continue
+        assert T >= MAX_NUM_TRS, f"Path {path} has too few TRs ({T}<{MAX_NUM_TRS})"
 
         series = series[:MAX_NUM_TRS]
         series, mean, std = nisc.scale(series)
 
         sample = {
-            **meta,
-            "path": str(path.relative_to(root)),
+            "sub": meta["sub"],
+            "site": meta["site"],
+            "dataset": meta["dataset"],
+            "path": str(path),
             "n_frames": MAX_NUM_TRS,
             "tr": TARGET_TR,
             "bold": series.astype(np.float16),
@@ -134,8 +147,41 @@ def generate_samples(paths: list[Path], *, root: AnyPath, reader: readers.Reader
         yield sample
 
 
+def prefetch(root: AnyPath, paths: list[str], *, max_workers: int = 1):
+    """Prefetch files from remote storage."""
+
+    with tempfile.TemporaryDirectory(prefix="prefetch-") as tmpdir:
+
+        def fn(path: str):
+            fullpath = root / path
+            if isinstance(fullpath, CloudPath):
+                tmppath = Path(tmpdir) / path
+                tmppath.parent.mkdir(parents=True, exist_ok=True)
+
+                # get sidecar too (hack)
+                stem = fullpath.name.split(".")[0]
+                sidecar = fullpath.parent / f"{stem}.json"
+                tmpsidecar = tmppath.parent / f"{stem}.json"
+                sidecar.download_to(tmpsidecar)
+
+                fullpath = fullpath.download_to(tmppath)
+
+            return path, fullpath
+
+        with ThreadPoolExecutor(max_workers) as executor:
+            futures = [executor.submit(fn, p) for p in paths]
+
+            for future in futures:
+                path, fullpath = future.result()
+                yield path, fullpath
+
+                if str(fullpath).startswith(tmpdir):
+                    fullpath.unlink()
+
+
 def parse_abide_metadata(path: Path):
     # CMU_a/sub-0050642/anat/sub-0050642_T1w.nii.gz
+    path = Path(path)
     dataset = path.parts[-4]
     site = dataset.split("_")[0]  # CMU_a -> CMU
     stem, ext = path.name.split(".", 1)
@@ -147,7 +193,11 @@ def parse_abide_metadata(path: Path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--space", type=str, default="fslr64k", choices=list(readers.READER_DICT))
+    parser.add_argument("--root", type=str, default=None)
+    parser.add_argument("--out-root", type=str, default=None)
+    parser.add_argument(
+        "--space", type=str, default="schaefer400", choices=list(readers.READER_DICT)
+    )
     parser.add_argument("--num_proc", "-j", type=int, default=32)
     args = parser.parse_args()
     sys.exit(main(args))

--- a/datasets/ABIDE/scripts/make_abide_arrow.py
+++ b/datasets/ABIDE/scripts/make_abide_arrow.py
@@ -40,8 +40,8 @@ def main(args):
     outdir = out_root / f"abide.{args.space}.arrow"
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # load table of curated subs and targets
     curated_df = pd.read_csv(ROOT / "metadata/ABIDE_curated.csv", dtype={"sub": str})

--- a/datasets/ABIDE/scripts/make_abide_arrow.sh
+++ b/datasets/ABIDE/scripts/make_abide_arrow.sh
@@ -20,6 +20,7 @@ ROOT="s3://medarc/fmri-fm-eval/ABIDE/fmriprep"
 OUT_ROOT="s3://medarc/fmri-datasets/eval"
 
 log_path="logs/make_abide_arrow.log"
+[[ -d logs ]] || mkdir logs
 
 for ii in $SPACEIDS; do
     space=${spaces[ii]}

--- a/datasets/ABIDE/scripts/make_abide_arrow.sh
+++ b/datasets/ABIDE/scripts/make_abide_arrow.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# all target spaces required by different models
+spaces=(
+    schaefer400
+    schaefer400_tians3
+    flat
+    a424
+    mni
+    mni_cortex
+    schaefer400_tians3_buckner7
+)
+
+# SPACEIDS="0 1 2 3 4 5 6"
+SPACEIDS="3 4 5 6"
+# ROOT="data/fmriprep"
+ROOT="s3://medarc/fmri-fm-eval/ABIDE/fmriprep"
+OUT_ROOT="s3://medarc/fmri-datasets/eval"
+
+log_path="logs/make_abide_arrow.log"
+
+for ii in $SPACEIDS; do
+    space=${spaces[ii]}
+    uv run python scripts/make_abide_arrow.py \
+        --root "${ROOT}" \
+        --out-root "${OUT_ROOT}" \
+        --space "${space}" \
+        2>&1 | tee -a "${log_path}"
+done

--- a/datasets/ABIDE/scripts/make_abide_dataset.py
+++ b/datasets/ABIDE/scripts/make_abide_dataset.py
@@ -44,7 +44,7 @@ def main(args):
     # list of included bold paths (one per sub)
     curated_paths = np.loadtxt(ROOT / "metadata/ABIDE_curated_paths.txt", dtype=str)
 
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         suffix = "_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz"
     else:
         suffix = "_space-fsLR_den-91k_bold.dtseries.nii"

--- a/datasets/ADHD200/scripts/make_adhd200_arrow.py
+++ b/datasets/ADHD200/scripts/make_adhd200_arrow.py
@@ -47,7 +47,7 @@ def main(args):
     curated_df = pd.read_csv(ROOT / "metadata/ADHD200_curated.csv", dtype={"sub": str})
     curated_paths = curated_df["path"].values
 
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         suffix = "_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz"
     else:
         suffix = "_space-fsLR_den-91k_bold.dtseries.nii"

--- a/datasets/ADHD200/scripts/make_adhd200_arrow.py
+++ b/datasets/ADHD200/scripts/make_adhd200_arrow.py
@@ -40,8 +40,8 @@ def main(args):
     outdir = out_root / f"adhd200.{args.space}.arrow"
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # load table of curated subs and targets
     curated_df = pd.read_csv(ROOT / "metadata/ADHD200_curated.csv", dtype={"sub": str})

--- a/datasets/ADHD200/scripts/make_adhd200_arrow.sh
+++ b/datasets/ADHD200/scripts/make_adhd200_arrow.sh
@@ -13,12 +13,14 @@ spaces=(
     schaefer400_tians3_buckner7
 )
 
-SPACEIDS="0 1 2 3 4 6"
+# SPACEIDS="0 1 2 3 4 6"
+SPACEIDS="3 4 5 6"
 # ROOT="data/fmriprep"
 ROOT="s3://medarc/fmri-fm-eval/ADHD200/fmriprep"
 OUT_ROOT="s3://medarc/fmri-datasets/eval"
 
 log_path="logs/make_adhd200_arrow.log"
+[[ -d logs ]] || mkdir logs
 
 for ii in $SPACEIDS; do
     space=${spaces[ii]}

--- a/datasets/ADNI/scripts/make_adni_eval.py
+++ b/datasets/ADNI/scripts/make_adni_eval.py
@@ -100,7 +100,7 @@ def main(args):
         ses = scandate_to_ses(scandate)
 
         # Build file path based on space
-        if args.space in {"mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+        if args.space in readers.VOLUME_SPACES:
             # Volumetric MNI path
             file_path = (
                 ADNI_OUTPUT
@@ -136,10 +136,7 @@ def main(args):
         _logger.info("Num samples (%s): %d", split, len(samples))
 
     # Load reader for target space
-    if args.space == "a424":
-        reader = readers.a424_reader(cifti=True)
-    else:
-        reader = readers.READER_DICT[args.space]()
+    reader = readers.READER_DICT[args.space]()
     dim = readers.DATA_DIMS[args.space]
     _logger.info("Using reader for space '%s' with dimension: %d", args.space, dim)
 

--- a/datasets/HCP-YA/scripts/make_hcpya_all_wds.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_all_wds.py
@@ -93,7 +93,7 @@ def main(args):
     batch_series_paths = sorted(meta_df.loc[sub_mask, "path"].values)
 
     # volume space for a424 and mni, otherwise cifti space
-    if args.space in {"a424", "mni", "mni_cortex"}:
+    if args.space in readers.VOLUME_SPACES:
         batch_series_paths = [
             p.replace("_Atlas_MSMAll.dtseries.nii", ".nii.gz") for p in batch_series_paths
         ]

--- a/datasets/HCP-YA/scripts/make_hcpya_arrow.sh
+++ b/datasets/HCP-YA/scripts/make_hcpya_arrow.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-if [[ -z $1 || $1 == "-h" || $1 == "--help" ]]; then
-    echo "make_hcpya_arrow.sh DATASET"
-    exit
-fi
-
-DATASET=$1
-SPACEIDS="0 1 2 3 4 5 6"
-
 # all target spaces required by different models
 spaces=(
     schaefer400
@@ -25,19 +17,29 @@ roots=(
     data/sourcedata/HCP_1200
     data/sourcedata/HCP_1200
     data/sourcedata/HCP_1200
-    s3://hcp-openaccess/HCP_1200
+    data/sourcedata/HCP_1200
     s3://hcp-openaccess/HCP_1200
     s3://hcp-openaccess/HCP_1200
     s3://hcp-openaccess/HCP_1200
 )
 
-log_path="logs/make_hcpya_${DATASET}_arrow.log"
+OUT_ROOT="s3://medarc/fmri-datasets/eval"
+
+# SPACEIDS="0 1 2 3 4 5 6"
+SPACEIDS="3 4 5 6"
+
+log_path="logs/make_hcpya_arrow.log"
+
+datasets="rest1lr task21 clips"
 
 for ii in $SPACEIDS; do
     space=${spaces[ii]}
     root=${roots[ii]}
-    uv run python scripts/make_hcpya_${DATASET}_arrow.py \
-        --space "${space}" \
-        --root "${root}" \
-        2>&1 | tee -a "${log_path}"
+    for dataset in $datasets; do
+        uv run python scripts/make_hcpya_${dataset}_arrow.py \
+            --space "${space}" \
+            --root "${root}" \
+            --out-root "${OUT_ROOT}" \
+            2>&1 | tee -a "${log_path}"
+    done
 done

--- a/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -9,7 +10,8 @@ from pathlib import Path
 import datasets as hfds
 import numpy as np
 import pandas as pd
-from cloudpathlib import AnyPath, CloudPath
+from cloudpathlib import AnyPath, CloudPath, S3Client, S3Path
+from boto3.s3.transfer import TransferConfig
 
 import fmri_fm_eval.nisc as nisc
 import fmri_fm_eval.readers as readers
@@ -58,11 +60,17 @@ SEED = 8581
 
 
 def main(args):
-    outdir = ROOT / f"data/processed/hcpya-clips.{args.space}.arrow"
+    out_root = AnyPath(args.out_root or (ROOT / "data/processed"))
+    outdir = out_root / f"hcpya-clips.{args.space}.arrow"
+
+    upload_client = get_s3_client()
+    if isinstance(outdir, CloudPath):
+        outdir = CloudPath(outdir, client=upload_client)
+
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # construct train/val/test splits by combining subject batches.
     # nb, across batches subjects are unrelated. we use the batches to dial how much
@@ -137,8 +145,15 @@ def main(args):
             )
         dataset = hfds.DatasetDict(dataset_dict)
 
-        outdir.parent.mkdir(exist_ok=True, parents=True)
-        dataset.save_to_disk(outdir, max_shard_size="300MB")
+        if isinstance(outdir, S3Path):
+            _logger.info("Saving to s3: %s", outdir)
+            tmp_outdir = Path(tmpdir) / outdir.name
+            # in theory save_to_disk should support s3, but idk why it wasn't working
+            dataset.save_to_disk(tmp_outdir, max_shard_size="300MB")
+            outdir.upload_from(tmp_outdir)
+        else:
+            _logger.info("Saving locally: %s", outdir)
+            dataset.save_to_disk(outdir, max_shard_size="300MB")
 
 
 def generate_samples(paths: list[str], *, root: AnyPath, reader: readers.Reader):
@@ -207,9 +222,30 @@ def parse_hcp_metadata(path: Path) -> dict[str, str]:
     return metadata
 
 
+def get_s3_client():
+    config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        multipart_chunksize=8 * 1024 * 1024,
+        max_concurrency=16,
+        use_threads=True,
+    )
+
+    if "R2_ACCESS_KEY_ID" in os.environ:
+        client = S3Client(
+            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            endpoint_url=os.environ["R2_ENDPOINT_URL_S3"],
+            boto3_transfer_config=config,
+        )
+    else:
+        client = S3Client(boto3_transfer_config=config)
+    return client
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=str, default=None)
+    parser.add_argument("--out-root", type=str, default=None)
     parser.add_argument(
         "--space", type=str, default="schaefer400", choices=list(readers.READER_DICT)
     )

--- a/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
@@ -226,7 +226,7 @@ def get_s3_client():
     config = TransferConfig(
         multipart_threshold=8 * 1024 * 1024,
         multipart_chunksize=8 * 1024 * 1024,
-        max_concurrency=16,
+        max_concurrency=10,
         use_threads=True,
     )
 

--- a/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_clips_arrow.py
@@ -87,11 +87,7 @@ def main(args):
         path_splits[split] = split_paths
         _logger.info(f"Split ({split}): N={len(split_paths)}\n{split_paths[:5]}")
 
-    # volume space for a424 and mni, otherwise cifti space
-    # TODO: hacky, the reader should know what input space it needs. we shouldn't need
-    # to remember this in every script.
-    # TDOO: indeed, this sucks
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         for split, split_paths in path_splits.items():
             path_splits[split] = [
                 p.replace("_Atlas_MSMAll.dtseries.nii", ".nii.gz") for p in split_paths

--- a/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -9,7 +10,8 @@ from pathlib import Path
 import datasets as hfds
 import numpy as np
 import pandas as pd
-from cloudpathlib import AnyPath, CloudPath
+from cloudpathlib import AnyPath, CloudPath, S3Client, S3Path
+from boto3.s3.transfer import TransferConfig
 
 import fmri_fm_eval.nisc as nisc
 import fmri_fm_eval.readers as readers
@@ -58,11 +60,17 @@ SEED = 8581
 
 
 def main(args):
-    outdir = ROOT / f"data/processed/hcpya-rest1lr.{args.space}.arrow"
+    out_root = AnyPath(args.out_root or (ROOT / "data/processed"))
+    outdir = out_root / f"hcpya-rest1lr.{args.space}.arrow"
+
+    upload_client = get_s3_client()
+    if isinstance(outdir, CloudPath):
+        outdir = CloudPath(outdir, client=upload_client)
+
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # construct train/val/test splits by combining subject batches.
     # nb, across batches subjects are unrelated. we use the batches to dial how much
@@ -171,8 +179,15 @@ def main(args):
             )
         dataset = hfds.DatasetDict(dataset_dict)
 
-        outdir.parent.mkdir(exist_ok=True, parents=True)
-        dataset.save_to_disk(outdir, max_shard_size="300MB")
+        if isinstance(outdir, S3Path):
+            _logger.info("Saving to s3: %s", outdir)
+            tmp_outdir = Path(tmpdir) / outdir.name
+            # in theory save_to_disk should support s3, but idk why it wasn't working
+            dataset.save_to_disk(tmp_outdir, max_shard_size="300MB")
+            outdir.upload_from(tmp_outdir)
+        else:
+            _logger.info("Saving locally: %s", outdir)
+            dataset.save_to_disk(outdir, max_shard_size="300MB")
 
 
 def generate_samples(
@@ -280,9 +295,30 @@ def stratify_subsample(
     return indices
 
 
+def get_s3_client():
+    config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        multipart_chunksize=8 * 1024 * 1024,
+        max_concurrency=16,
+        use_threads=True,
+    )
+
+    if "R2_ACCESS_KEY_ID" in os.environ:
+        client = S3Client(
+            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            endpoint_url=os.environ["R2_ENDPOINT_URL_S3"],
+            boto3_transfer_config=config,
+        )
+    else:
+        client = S3Client(boto3_transfer_config=config)
+    return client
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=str, default=None)
+    parser.add_argument("--out-root", type=str, default=None)
     parser.add_argument(
         "--space", type=str, default="schaefer400", choices=list(readers.READER_DICT)
     )

--- a/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
@@ -113,10 +113,7 @@ def main(args):
         assert len(paths) == NUM_SUBS[split], "unexpected number of paths"
 
     # volume space for a424 and mni, otherwise cifti space
-    # TODO: hacky, the reader should know what input space it needs. we shouldn't need
-    # to remember this in every script.
-    # TODO: this sucks
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         for split, split_paths in path_splits.items():
             path_splits[split] = [
                 p.replace("_Atlas_MSMAll.dtseries.nii", ".nii.gz") for p in split_paths

--- a/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_rest1lr_arrow.py
@@ -299,7 +299,7 @@ def get_s3_client():
     config = TransferConfig(
         multipart_threshold=8 * 1024 * 1024,
         multipart_chunksize=8 * 1024 * 1024,
-        max_concurrency=16,
+        max_concurrency=10,
         use_threads=True,
     )
 

--- a/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -9,7 +10,8 @@ from pathlib import Path
 import datasets as hfds
 import numpy as np
 import pandas as pd
-from cloudpathlib import AnyPath, CloudPath
+from cloudpathlib import AnyPath, CloudPath, S3Client, S3Path
+from boto3.s3.transfer import TransferConfig
 
 import fmri_fm_eval.nisc as nisc
 import fmri_fm_eval.readers as readers
@@ -79,11 +81,17 @@ HCP_TASK21_TRIAL_TYPES = {
 
 
 def main(args):
-    outdir = ROOT / f"data/processed/hcpya-task21.{args.space}.arrow"
+    out_root = AnyPath(args.out_root or (ROOT / "data/processed"))
+    outdir = out_root / f"hcpya-task21.{args.space}.arrow"
+
+    upload_client = get_s3_client()
+    if isinstance(outdir, CloudPath):
+        outdir = CloudPath(outdir, client=upload_client)
+
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # construct train/val/test splits by combining subject batches.
     # nb, across batches subjects are unrelated. we use the batches to dial how much
@@ -179,8 +187,15 @@ def main(args):
             )
         dataset = hfds.DatasetDict(dataset_dict)
 
-        outdir.parent.mkdir(exist_ok=True, parents=True)
-        dataset.save_to_disk(outdir, max_shard_size="300MB")
+        if isinstance(outdir, S3Path):
+            _logger.info("Saving to s3: %s", outdir)
+            tmp_outdir = Path(tmpdir) / outdir.name
+            # in theory save_to_disk should support s3, but idk why it wasn't working
+            dataset.save_to_disk(tmp_outdir, max_shard_size="300MB")
+            outdir.upload_from(tmp_outdir)
+        else:
+            _logger.info("Saving locally: %s", outdir)
+            dataset.save_to_disk(outdir, max_shard_size="300MB")
 
 
 def generate_samples(
@@ -268,9 +283,30 @@ def parse_hcp_metadata(path: Path) -> dict[str, str]:
     return metadata
 
 
+def get_s3_client():
+    config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        multipart_chunksize=8 * 1024 * 1024,
+        max_concurrency=16,
+        use_threads=True,
+    )
+
+    if "R2_ACCESS_KEY_ID" in os.environ:
+        client = S3Client(
+            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            endpoint_url=os.environ["R2_ENDPOINT_URL_S3"],
+            boto3_transfer_config=config,
+        )
+    else:
+        client = S3Client(boto3_transfer_config=config)
+    return client
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=str, default=None)
+    parser.add_argument("--out-root", type=str, default=None)
     parser.add_argument(
         "--space", type=str, default="schaefer400", choices=list(readers.READER_DICT)
     )

--- a/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
@@ -123,10 +123,7 @@ def main(args):
 
         path_splits[split] = sorted(sub_df["path"].tolist())
 
-    # volume space for a424 and mni, otherwise cifti space
-    # TODO: hacky, the reader should know what input space it needs. we shouldn't need
-    # to remember this in every script.
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         for split, split_paths in path_splits.items():
             path_splits[split] = [
                 p.replace("_Atlas_MSMAll.dtseries.nii", ".nii.gz") for p in split_paths

--- a/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
+++ b/datasets/HCP-YA/scripts/make_hcpya_task21_arrow.py
@@ -287,7 +287,7 @@ def get_s3_client():
     config = TransferConfig(
         multipart_threshold=8 * 1024 * 1024,
         multipart_chunksize=8 * 1024 * 1024,
-        max_concurrency=16,
+        max_concurrency=10,
         use_threads=True,
     )
 

--- a/datasets/PPMI/scripts/make_ppmi_dataset.py
+++ b/datasets/PPMI/scripts/make_ppmi_dataset.py
@@ -42,8 +42,8 @@ def main(args):
     outdir = out_root / f"ppmi.{args.space}.arrow"
     _logger.info("Generating dataset: %s", outdir)
     if outdir.exists():
-        _logger.warning("Output %s exists; exiting.", outdir)
-        return 1
+        _logger.info("Output %s exists; exiting.", outdir)
+        return
 
     # load curated subjects
     curated_df = pd.read_csv(ROOT / "metadata/PPMI_curated.csv", dtype={"Subject": str})

--- a/datasets/PPMI/scripts/make_ppmi_dataset.py
+++ b/datasets/PPMI/scripts/make_ppmi_dataset.py
@@ -58,7 +58,7 @@ def main(args):
             curated_paths[sub] = path
     curated_paths = list(curated_paths.values())
 
-    if args.space in {"a424", "mni", "mni_cortex", "schaefer400_tians3_buckner7"}:
+    if args.space in readers.VOLUME_SPACES:
         suffix = "_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz"
     else:
         suffix = "_space-fsLR_den-91k_bold.dtseries.nii"

--- a/datasets/PPMI/scripts/make_ppmi_dataset.sh
+++ b/datasets/PPMI/scripts/make_ppmi_dataset.sh
@@ -13,7 +13,8 @@ spaces=(
     schaefer400_tians3_buckner7
 )
 
-SPACEIDS="0 1 2 3 4 6"
+# SPACEIDS="0 1 2 3 4 6"
+SPACEIDS="3 4 5 6"
 # ROOT="data/fmriprep"
 ROOT="s3://medarc/fmri-fm-eval/PPMI/fmriprep"
 OUT_ROOT="s3://medarc/fmri-datasets/eval"

--- a/src/fmri_fm_eval/models/swift.py
+++ b/src/fmri_fm_eval/models/swift.py
@@ -120,7 +120,7 @@ class SwiftTransform:
         roi_path = tflow.get(
             "MNI152NLin6Asym", desc="brain", resolution=2, suffix="mask", extension="nii.gz"
         )
-        mask = nisc.read_nifti_data(roi_path) > 0  # (Z, Y, X)
+        mask = nisc.read_mni152_2mm_data(roi_path) > 0  # (Z, Y, X)
 
         self.mask = torch.from_numpy(mask)
         self.mask_shape = mask.shape

--- a/src/fmri_fm_eval/readers.py
+++ b/src/fmri_fm_eval/readers.py
@@ -1,9 +1,7 @@
 from typing import Protocol
 
-import nibabel as nib
 import numpy as np
 from templateflow import api as tflow
-from nilearn.image import resample_img
 
 from . import nisc
 
@@ -56,11 +54,11 @@ def schaefer400_tians3_reader() -> Reader:
     return fn
 
 
-def a424_reader(cifti: bool = False) -> Reader:
-    parcavg = nisc.parcel_average_a424(cifti=cifti)
+def a424_reader() -> Reader:
+    parcavg = nisc.parcel_average_a424()
 
     def fn(path: str):
-        series = nisc.read_cifti_data(path) if cifti else nisc.read_nifti_data(path)
+        series = nisc.read_cifti_data(path)
         series = parcavg(series)
         return series
 
@@ -71,7 +69,7 @@ def schaefer400_tians3_buckner7_reader() -> Reader:
     parcavg = nisc.parcel_average_schaefer400_tians3_buckner7()
 
     def fn(path: str):
-        series = nisc.read_nifti_data(path)
+        series = nisc.read_mni152_2mm_data(path, interpolation="linear")
         series = parcavg(series)
         return series
 
@@ -95,13 +93,10 @@ def flat_reader() -> Reader:
 
 def mni_cortex_reader() -> Reader:
     roi_path = nisc.fetch_schaefer(400, space="mni")
-    roi_img = nib.load(roi_path)
-    mask = np.ascontiguousarray(roi_img.get_fdata().T) > 0
+    mask = nisc.read_mni152_2mm_data(roi_path, interpolation="nearest") > 0
 
     def fn(path: str):
-        img = nib.load(path)
-        img = _ensure_mni152_2mm(img)
-        series = np.ascontiguousarray(img.get_fdata().T)
+        series = nisc.read_mni152_2mm_data(path, interpolation="linear")
         series = series[:, mask]
         return series
 
@@ -112,39 +107,29 @@ def mni_reader() -> Reader:
     roi_path = tflow.get(
         "MNI152NLin6Asym", desc="brain", resolution=2, suffix="mask", extension="nii.gz"
     )
-    roi_img = nib.load(roi_path)
-    mask = np.ascontiguousarray(roi_img.get_fdata().T) > 0
+    mask = nisc.read_mni152_2mm_data(roi_path, interpolation="nearest") > 0
 
     def fn(path: str):
-        img = nib.load(path)
-        img = _ensure_mni152_2mm(img)
-        series = np.ascontiguousarray(img.get_fdata().T)
+        series = nisc.read_mni152_2mm_data(path, interpolation="linear")
         series = series[:, mask]
         return series
 
     return fn
 
 
+# NOTE: this changed from LAS to RAS orientation on 2026-01-14
+# MNI derived spaces generated before this date are invalid:
+#   - a424 (cifti=False)
+#   - schaefer400_tians3_buckner7
+#   - mni
+#   - mni_cortex
 MNI152_2MM_SHAPE = (91, 109, 91)
 MNI152_2MM_AFFINE = (
-    (-2.0, 0.0, 0.0, 90.0),
+    (2.0, 0.0, 0.0, -90.0),
     (0.0, 2.0, 0.0, -126.0),
     (0.0, 0.0, 2.0, -72.0),
     (0.0, 0.0, 0.0, 1.0),
 )
-
-
-def _ensure_mni152_2mm(img: nib.Nifti1Image, interpolation: str = "linear"):
-    if img.shape[:3] != MNI152_2MM_SHAPE:
-        img = resample_img(
-            img,
-            target_affine=np.array(MNI152_2MM_AFFINE),
-            target_shape=MNI152_2MM_SHAPE,
-            interpolation=interpolation,
-            force_resample=True,
-            copy_header=True,
-        )
-    return img
 
 
 READER_DICT = {
@@ -170,4 +155,11 @@ DATA_DIMS = {
     "flat": 77763,
     "mni": 228483,
     "mni_cortex": 132032,
+}
+
+
+VOLUME_SPACES = {
+    "schaefer400_tians3_buckner7",
+    "mni",
+    "mni_cortex",
 }


### PR DESCRIPTION
This fixes a bug in MNI derived data generation where data were being loaded with inconsistent left right orientation. This is due to FSL, HCP, and some ROIs being in LAS orientation, whereas fMRIPrep, templateflow use RAS orientation. Here we enforce that all MNI 152 data has a consistent shape and orientation when loading before extracting the data array.

I'm also updating the A424 space to use cifti by default, since it's based on the Glasser parcellation which is natively surface based.

I'm regenerated the eval datasets for all affected spaces. @mihirneal can you regenerate for ADNI and AABC?

@ckadirt can you check the SwIFT (and now NeuroSTORM) implementations to see if they expect LAS or RAS?

(Also note, there are some misc diffs due to pre-commit.)