### PR TITLE
Dataset loading improvements

### DIFF
--- a/src/fmri_fm_eval/config/default_logistic.yaml
+++ b/src/fmri_fm_eval/config/default_logistic.yaml
@@ -1,9 +1,9 @@
 # Root output directory
 # Individual eval runs will be saved as:
 #
-#   output_root/{name_prefix}/{model}/{representation}/{dataset}
+#   output_root/{name_prefix}/{dataset}__{model}__{representation}__{classifier}
 output_root: output
-name_prefix: logistic_eval
+name_prefix: eval_logistic
 
 # Remote root for backing up results
 # currently only S3 supported

--- a/src/fmri_fm_eval/config/default_probe.yaml
+++ b/src/fmri_fm_eval/config/default_probe.yaml
@@ -1,9 +1,9 @@
 # Root output directory
 # Individual eval runs will be saved as:
 #
-#   output_root/{name_prefix}/{model}/{representation}/{dataset}
+#   output_root/{name_prefix}/{dataset}__{model}__{representation}__{classifier}
 output_root: output
-name_prefix: probe_eval
+name_prefix: eval_probe
 
 # Remote root for backing up results
 # currently only S3 supported

--- a/src/fmri_fm_eval/config/default_probe.yaml
+++ b/src/fmri_fm_eval/config/default_probe.yaml
@@ -36,7 +36,7 @@ prefetch_factor: 8
 balanced_sampling: false
 
 # Optimization
-epochs: 20
+epochs: 4
 steps_per_epoch: 500
 # total_batch_size = batch_size * accum_iter
 batch_size: 32

--- a/src/fmri_fm_eval/datasets/aabc.py
+++ b/src/fmri_fm_eval/datasets/aabc.py
@@ -2,17 +2,11 @@ import os
 import json
 
 import fsspec
-import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
-AABC_ROOT = os.getenv("AABC_ROOT")
-assert AABC_ROOT is not None, (
-    "AABC_ROOT environment variable is not set. "
-    "Please set it to the directory containing AABC data. "
-    "Example: export AABC_ROOT=/path/to/aabc-eval"
-)
+AABC_ROOT = os.getenv("AABC_ROOT", "s3://medarc/fmri-datasets/eval")
 
 AABC_TARGET_MAP_DICT = {
     # Demographics
@@ -43,13 +37,7 @@ def _create_aabc(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{AABC_ROOT}/aabc.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
         dataset = HFDataset(dataset, target_key=target_key, target_map=target_map)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/aabc.py
+++ b/src/fmri_fm_eval/datasets/aabc.py
@@ -4,7 +4,7 @@ import json
 import fsspec
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 AABC_ROOT = os.getenv("AABC_ROOT")
@@ -43,7 +43,13 @@ def _create_aabc(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{AABC_ROOT}/aabc.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key=target_key, target_map=target_map)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/abide.py
+++ b/src/fmri_fm_eval/datasets/abide.py
@@ -4,7 +4,7 @@ import os
 import datasets as hfds
 import fsspec
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 ABIDE_ROOT = os.getenv("ABIDE_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -28,7 +28,13 @@ def _create_abide(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ABIDE_ROOT}/abide.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key=target_key, target_map=target_map)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/abide.py
+++ b/src/fmri_fm_eval/datasets/abide.py
@@ -1,10 +1,9 @@
 import json
 import os
 
-import datasets as hfds
 import fsspec
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
 ABIDE_ROOT = os.getenv("ABIDE_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -28,13 +27,7 @@ def _create_abide(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ABIDE_ROOT}/abide.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
         dataset = HFDataset(dataset, target_key=target_key, target_map=target_map)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/adhd200.py
+++ b/src/fmri_fm_eval/datasets/adhd200.py
@@ -2,7 +2,7 @@ import os
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 ADHD200_ROOT = os.getenv("ADHD200_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -13,7 +13,13 @@ def _create_adhd200(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ADHD200_ROOT}/adhd200.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key=target)
         dataset_dict[split] = dataset
     return dataset_dict

--- a/src/fmri_fm_eval/datasets/adhd200.py
+++ b/src/fmri_fm_eval/datasets/adhd200.py
@@ -1,8 +1,7 @@
 import os
 
-import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
 ADHD200_ROOT = os.getenv("ADHD200_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -13,13 +12,7 @@ def _create_adhd200(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ADHD200_ROOT}/adhd200.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
         dataset = HFDataset(dataset, target_key=target)
         dataset_dict[split] = dataset
     return dataset_dict

--- a/src/fmri_fm_eval/datasets/adni.py
+++ b/src/fmri_fm_eval/datasets/adni.py
@@ -4,15 +4,10 @@ from pathlib import Path
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
-ADNI_ROOT = os.getenv("ADNI_ROOT")
-assert ADNI_ROOT is not None, (
-    "ADNI_ROOT environment variable is not set. "
-    "Please set it to the directory containing ADNI processed data. "
-)
-ADNI_ROOT = Path(ADNI_ROOT)
+ADNI_ROOT = Path(os.getenv("ADNI_ROOT", "s3://medarc/fmri-datasets/eval"))
 
 ADNI_TARGET_MAP_DICT = {
     # Demographics
@@ -49,13 +44,7 @@ def _create_adni(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ADNI_ROOT}/adni.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
 
         # For ADNI, we need custom target key mapping since targets are keyed by PTID_SCANDATE
         # We'll use a custom wrapper that builds the key from sub and visit

--- a/src/fmri_fm_eval/datasets/adni.py
+++ b/src/fmri_fm_eval/datasets/adni.py
@@ -1,13 +1,13 @@
 import json
 import os
-from pathlib import Path
 
 import datasets as hfds
+import fsspec
 
 from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
-ADNI_ROOT = Path(os.getenv("ADNI_ROOT", "s3://medarc/fmri-datasets/eval"))
+ADNI_ROOT = os.getenv("ADNI_ROOT", "s3://medarc/fmri-datasets/eval")
 
 ADNI_TARGET_MAP_DICT = {
     # Demographics
@@ -36,8 +36,9 @@ def _create_adni(space: str, target: str, **kwargs):
     """
     # Load target map
     target_map_path = ADNI_TARGET_MAP_DICT[target]
-    target_map_path = ADNI_ROOT / "targets" / target_map_path
-    with open(target_map_path) as f:
+    target_map_path = f"{ADNI_ROOT}/targets/{target_map_path}"
+
+    with fsspec.open(target_map_path, "r") as f:
         target_map = json.load(f)
 
     dataset_dict = {}
@@ -80,6 +81,9 @@ def build_sample_key(sub: str, visit: str) -> str:
         scandate = visit  # Fallback
 
     return f"{ptid}_{scandate}"
+
+
+# TODO: fix this duplication
 
 
 class ADNIDataset(HFDataset):

--- a/src/fmri_fm_eval/datasets/adni.py
+++ b/src/fmri_fm_eval/datasets/adni.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 ADNI_ROOT = os.getenv("ADNI_ROOT")
@@ -49,7 +49,13 @@ def _create_adni(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{ADNI_ROOT}/adni.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
 
         # For ADNI, we need custom target key mapping since targets are keyed by PTID_SCANDATE
         # We'll use a custom wrapper that builds the key from sub and visit
@@ -72,9 +78,9 @@ def build_sample_key(sub: str, visit: str) -> str:
     # Reconstruct PTID from sub
     # sub format: "168S6049" -> PTID format: "168_S_6049"
     # Find the 'S' position and insert underscores
-    s_pos = sub.find('S')
+    s_pos = sub.find("S")
     if s_pos > 0:
-        ptid = f"{sub[:s_pos]}_S_{sub[s_pos+1:]}"
+        ptid = f"{sub[:s_pos]}_S_{sub[s_pos + 1 :]}"
     else:
         ptid = sub  # Fallback
 

--- a/src/fmri_fm_eval/datasets/base.py
+++ b/src/fmri_fm_eval/datasets/base.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any, Callable
 
@@ -5,6 +6,12 @@ import datasets as hfds
 import numpy as np
 import pandas as pd
 import torch
+
+hfds.disable_progress_bars()
+
+# parallelize download
+HF_NUM_PROC = min(int(os.getenv("OMP_NUM_THREADS", "8")), 8)
+HF_DOWNLOAD_CONFIG = hfds.DownloadConfig(num_proc=HF_NUM_PROC)
 
 
 class HFDataset(torch.utils.data.Dataset):

--- a/src/fmri_fm_eval/datasets/base.py
+++ b/src/fmri_fm_eval/datasets/base.py
@@ -110,7 +110,8 @@ def load_arrow_dataset(path: str | Path, cache_dir: str | Path | None = None, **
 
     # try handle race condition when multiple jobs attempt to download the same dataset
     # TODO: think more about this
-    with FileLock(f"{cache_dir}/.{path.name}.lock"):
+    dataset_name = str(path.relative_to(path.parents[1])).replace("/", "__")
+    with FileLock(f"{cache_dir}/.{dataset_name}.lock"):
         dataset = hfds.load_dataset(
             "arrow",
             data_files=f"{path}/*.arrow",

--- a/src/fmri_fm_eval/datasets/base.py
+++ b/src/fmri_fm_eval/datasets/base.py
@@ -6,6 +6,9 @@ import datasets as hfds
 import numpy as np
 import pandas as pd
 import torch
+from cloudpathlib import AnyPath
+from filelock import FileLock
+from datasets.config import HF_DATASETS_CACHE
 
 hfds.disable_progress_bars()
 
@@ -93,3 +96,27 @@ class HFDataset(torch.utils.data.Dataset):
         )
         s = f"HFDataset(\n{s}\n)"
         return s
+
+
+def load_arrow_dataset(path: str | Path, cache_dir: str | Path | None = None, **kwargs):
+    # try to give a more informative error message if a dataset doesn't exist
+    # hf error message is pretty useless
+    path = AnyPath(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset {path} does not exist")
+
+    cache_dir = Path(cache_dir or HF_DATASETS_CACHE)
+    cache_dir.mkdir(exist_ok=True, parents=True)
+
+    # try handle race condition when multiple jobs attempt to download the same dataset
+    # TODO: think more about this
+    with FileLock(f"{cache_dir}/.{path.name}.lock"):
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{path}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            cache_dir=cache_dir,
+            **kwargs,
+        )
+    return dataset

--- a/src/fmri_fm_eval/datasets/hcpya.py
+++ b/src/fmri_fm_eval/datasets/hcpya.py
@@ -2,7 +2,7 @@ import os
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 HCPYA_ROOT = os.getenv("HCPYA_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -42,7 +42,13 @@ def _create_hcpya(
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{HCPYA_ROOT}/hcpya-{name}.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key=target_key)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/hcpya.py
+++ b/src/fmri_fm_eval/datasets/hcpya.py
@@ -1,8 +1,7 @@
 import os
 
-import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
 HCPYA_ROOT = os.getenv("HCPYA_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -42,13 +41,7 @@ def _create_hcpya(
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{HCPYA_ROOT}/hcpya-{name}.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url)
         dataset = HFDataset(dataset, target_key=target_key)
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/nsd.py
+++ b/src/fmri_fm_eval/datasets/nsd.py
@@ -2,7 +2,7 @@ import os
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 NSD_ROOT = os.getenv("NSD_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -14,7 +14,13 @@ def nsd_cococlip(space: str, **kwargs):
     splits = ["train", "validation", "test", "testid"]
     for split in splits:
         url = f"{NSD_ROOT}/nsd-cococlip.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key="category_id")
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/nsd.py
+++ b/src/fmri_fm_eval/datasets/nsd.py
@@ -1,8 +1,7 @@
 import os
 
-import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
 NSD_ROOT = os.getenv("NSD_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -14,13 +13,7 @@ def nsd_cococlip(space: str, **kwargs):
     splits = ["train", "validation", "test", "testid"]
     for split in splits:
         url = f"{NSD_ROOT}/nsd-cococlip.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
         dataset = HFDataset(dataset, target_key="category_id")
         dataset_dict[split] = dataset
 

--- a/src/fmri_fm_eval/datasets/ppmi.py
+++ b/src/fmri_fm_eval/datasets/ppmi.py
@@ -1,8 +1,7 @@
 import os
 
-import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
+from fmri_fm_eval.datasets.base import HFDataset, load_arrow_dataset
 from fmri_fm_eval.datasets.registry import register_dataset
 
 PPMI_ROOT = os.getenv("PPMI_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -13,13 +12,7 @@ def _create_ppmi(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{PPMI_ROOT}/ppmi.{space}.arrow/{split}"
-        dataset = hfds.load_dataset(
-            "arrow",
-            data_files=f"{url}/*.arrow",
-            split="train",
-            download_config=HF_DOWNLOAD_CONFIG,
-            **kwargs,
-        )
+        dataset = load_arrow_dataset(url, **kwargs)
         dataset = HFDataset(dataset, target_key=target)
         dataset_dict[split] = dataset
     return dataset_dict

--- a/src/fmri_fm_eval/datasets/ppmi.py
+++ b/src/fmri_fm_eval/datasets/ppmi.py
@@ -2,7 +2,7 @@ import os
 
 import datasets as hfds
 
-from fmri_fm_eval.datasets.base import HFDataset
+from fmri_fm_eval.datasets.base import HFDataset, HF_DOWNLOAD_CONFIG
 from fmri_fm_eval.datasets.registry import register_dataset
 
 PPMI_ROOT = os.getenv("PPMI_ROOT", "s3://medarc/fmri-datasets/eval")
@@ -13,7 +13,13 @@ def _create_ppmi(space: str, target: str, **kwargs):
     splits = ["train", "validation", "test"]
     for split in splits:
         url = f"{PPMI_ROOT}/ppmi.{space}.arrow/{split}"
-        dataset = hfds.load_dataset("arrow", data_files=f"{url}/*.arrow", split="train", **kwargs)
+        dataset = hfds.load_dataset(
+            "arrow",
+            data_files=f"{url}/*.arrow",
+            split="train",
+            download_config=HF_DOWNLOAD_CONFIG,
+            **kwargs,
+        )
         dataset = HFDataset(dataset, target_key=target)
         dataset_dict[split] = dataset
     return dataset_dict

--- a/src/fmri_fm_eval/main_probe.py
+++ b/src/fmri_fm_eval/main_probe.py
@@ -46,7 +46,7 @@ def main(args: DictConfig):
     if not args.get("name"):
         args.name = (
             f"{args.name_prefix}/"
-            f"{args.model}/{args.representation}__{args.classifier}/{args.dataset}"
+            f"{args.dataset}__{args.model}__{args.representation}__{args.classifier}"
         )
     args.output_dir = f"{args.output_root}/{args.name}"
     output_dir = Path(args.output_dir)

--- a/src/fmri_fm_eval/main_probe.py
+++ b/src/fmri_fm_eval/main_probe.py
@@ -94,9 +94,14 @@ def main(args: DictConfig):
 
     # dataset
     print(f"creating dataset: {args.dataset} ({backbone.__space__})")
-    dataset_dict = create_dataset(
-        args.dataset, space=backbone.__space__, **(args.dataset_kwargs or {})
-    )
+    try:
+        dataset_dict = create_dataset(
+            args.dataset, space=backbone.__space__, **(args.dataset_kwargs or {})
+        )
+    except FileNotFoundError:
+        print(f"dataset not found: {args.dataset} ({backbone.__space__}); exiting")
+        return
+
     for split, ds in dataset_dict.items():
         print(f"{split} (n={len(ds)}):\n{ds}\n")
     train_dataset: HFDataset = dataset_dict["train"]

--- a/src/fmri_fm_eval/main_probe.py
+++ b/src/fmri_fm_eval/main_probe.py
@@ -10,6 +10,7 @@ import json
 import importlib.metadata
 import math
 import time
+import traceback
 from collections import defaultdict
 from functools import partial
 from itertools import product
@@ -98,9 +99,9 @@ def main(args: DictConfig):
         dataset_dict = create_dataset(
             args.dataset, space=backbone.__space__, **(args.dataset_kwargs or {})
         )
-    except FileNotFoundError:
-        print(f"dataset not found: {args.dataset} ({backbone.__space__}); exiting")
-        return
+    except Exception as exc:
+        msg = traceback.format_exception_only(exc)[0]
+        print(f"error loading dataset: {args.dataset} ({backbone.__space__}); exiting\n\n{msg}")
 
     for split, ds in dataset_dict.items():
         print(f"{split} (n={len(ds)}):\n{ds}\n")

--- a/src/fmri_fm_eval/main_probe.py
+++ b/src/fmri_fm_eval/main_probe.py
@@ -436,6 +436,7 @@ def train_one_epoch(
     device: torch.device,
 ):
     model.train()
+    model.backbone.eval()
     use_cuda = device.type == "cuda"
     log_wandb = args.wandb and ut.is_main_process()
     print_freq = args.get("print_freq", 20) if not args.debug else 1

--- a/src/fmri_fm_eval/main_probe.py
+++ b/src/fmri_fm_eval/main_probe.py
@@ -7,6 +7,7 @@
 import argparse
 import datetime
 import json
+import importlib.metadata
 import math
 import time
 from collections import defaultdict
@@ -27,7 +28,6 @@ from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader, WeightedRandomSampler
 
 import fmri_fm_eval.utils as ut
-import fmri_fm_eval.version
 from fmri_fm_eval.classifiers import ClassifierGrid, create_classifier, list_classififiers
 from fmri_fm_eval.datasets.base import HFDataset
 from fmri_fm_eval.models.registry import create_model, list_models
@@ -79,7 +79,7 @@ def main(args: DictConfig):
     ut.setup_for_distributed(log_path=output_dir / "log.txt")
 
     print("fMRI foundation model probe eval")
-    print(f"version: {fmri_fm_eval.version.__version__}")
+    print(f"version: {importlib.metadata.version('fmri-fm-eval')}")
     print(ut.get_sha())
     print(f"cwd: {Path.cwd()}")
     print(f"start: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")


### PR DESCRIPTION
Misc updates mostly related to loading datasets:
- abstract out arrow dataset loading into a shared util since it's getting complicated. handle setting up parallel download and dealing with contention over the dataset from multiple parallel eval jobs (do we really need this? does hf not handle it?). also give a more informative message if the path doesn't exist.
- put backbone in eval mode during probe training (!)
- update AABC and ADNI to work with remote paths and set a default to the shared s3 dataset path. (note there is a duplicated `ADNIDataset` we should merge with `HFDataset` later)
- tensor -> float type fix for brain-semantoks when temporal resampling
- change default output directory naming to be more flat. annoying to look through so many directories
- change default epochs 20 -> 4
- pre-commit fmt