### PR TITLE
Add fMRIPrep confounds to abide Arrow dataset

### DIFF
--- a/datasets/ABIDE/scripts/make_abide_arrow.py
+++ b/datasets/ABIDE/scripts/make_abide_arrow.py
@@ -86,6 +86,8 @@ def main(args):
             "bold": hfds.Array2D(shape=(None, dim), dtype="float16"),
             "mean": hfds.Array2D(shape=(1, dim), dtype="float32"),
             "std": hfds.Array2D(shape=(1, dim), dtype="float32"),
+            "confounds": hfds.Sequence(hfds.Sequence(hfds.Value("float32"))), # Sequence(Sequence()) for variable column counts
+            "confounds_columns": hfds.Sequence(hfds.Value("string")),
         }
     )
 
@@ -133,6 +135,11 @@ def generate_samples(paths: list[Path], *, root: AnyPath, reader: readers.Reader
         series = series[:MAX_NUM_TRS]
         series, mean, std = nisc.scale(series)
 
+        # Load and resample confounds
+        confounds, confounds_columns = nisc.load_fmriprep_confounds(fullpath)
+        confounds = nisc.resample_timeseries(confounds, tr=tr, new_tr=TARGET_TR, kind="pchip")
+        confounds = confounds[:MAX_NUM_TRS]
+
         sample = {
             "sub": meta["sub"],
             "site": meta["site"],
@@ -143,6 +150,8 @@ def generate_samples(paths: list[Path], *, root: AnyPath, reader: readers.Reader
             "bold": series.astype(np.float16),
             "mean": mean.astype(np.float32),
             "std": std.astype(np.float32),
+            "confounds": confounds.tolist(),  # Convert to list for Sequence(Sequence())
+            "confounds_columns": confounds_columns,
         }
         yield sample
 
@@ -163,6 +172,12 @@ def prefetch(root: AnyPath, paths: list[str], *, max_workers: int = 1):
                 sidecar = fullpath.parent / f"{stem}.json"
                 tmpsidecar = tmppath.parent / f"{stem}.json"
                 sidecar.download_to(tmpsidecar)
+
+                # get confounds TSV file
+                confounds_prefix = stem.split("_space-")[0]
+                confounds_file = fullpath.parent / f"{confounds_prefix}_desc-confounds_timeseries.tsv"
+                tmp_confounds = tmppath.parent / f"{confounds_prefix}_desc-confounds_timeseries.tsv"
+                confounds_file.download_to(tmp_confounds)
 
                 fullpath = fullpath.download_to(tmppath)
 

--- a/datasets/ABIDE/scripts/make_abide_arrow.py
+++ b/datasets/ABIDE/scripts/make_abide_arrow.py
@@ -83,11 +83,13 @@ def main(args):
             "path": hfds.Value("string"),
             "n_frames": hfds.Value("int32"),
             "tr": hfds.Value("float32"),
+            "confounds": hfds.List(
+                hfds.List(hfds.Value("float32"))
+            ),  # List for variable column counts
+            "confounds_columns": hfds.List(hfds.Value("string")),
             "bold": hfds.Array2D(shape=(None, dim), dtype="float16"),
             "mean": hfds.Array2D(shape=(1, dim), dtype="float32"),
             "std": hfds.Array2D(shape=(1, dim), dtype="float32"),
-            "confounds": hfds.Sequence(hfds.Sequence(hfds.Value("float32"))), # Sequence(Sequence()) for variable column counts
-            "confounds_columns": hfds.Sequence(hfds.Value("string")),
         }
     )
 
@@ -175,7 +177,9 @@ def prefetch(root: AnyPath, paths: list[str], *, max_workers: int = 1):
 
                 # get confounds TSV file
                 confounds_prefix = stem.split("_space-")[0]
-                confounds_file = fullpath.parent / f"{confounds_prefix}_desc-confounds_timeseries.tsv"
+                confounds_file = (
+                    fullpath.parent / f"{confounds_prefix}_desc-confounds_timeseries.tsv"
+                )
                 tmp_confounds = tmppath.parent / f"{confounds_prefix}_desc-confounds_timeseries.tsv"
                 confounds_file.download_to(tmp_confounds)
 

--- a/src/fmri_fm_eval/nisc.py
+++ b/src/fmri_fm_eval/nisc.py
@@ -21,6 +21,7 @@ from typing import Any, Literal, NamedTuple
 import cortex
 import numpy as np
 import nibabel as nib
+import pandas as pd
 import scipy.interpolate
 import scipy.signal
 from matplotlib.tri import Triangulation
@@ -116,6 +117,42 @@ def read_gifti_surf_data(path: str | Path) -> np.ndarray:
 
     series = np.concatenate([series_lh, series_rh], axis=1)
     return series
+
+
+def load_fmriprep_confounds(bold_path: str | Path) -> tuple[np.ndarray, list[str]]:
+    """Load confounds from fMRIPrep output for any dataset.
+
+    The confounds file is expected to be in the same directory as the BOLD file,
+    with the naming pattern: {prefix}_desc-confounds_timeseries.tsv
+
+    Args:
+        bold_path: Path to BOLD file (*_bold.nii.gz or *_bold.dtseries.nii)
+
+    Returns:
+        confounds: array of shape (n_timesteps, n_confounds), float32
+        columns: list of column names
+    """
+    bold_path = Path(bold_path)
+
+    # Confounds file has same prefix (before _space-), different suffix
+    # e.g., sub-X_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii
+    #    -> sub-X_task-rest_run-1_desc-confounds_timeseries.tsv
+    stem = bold_path.name
+    if "_space-" in stem:
+        prefix = stem.split("_space-")[0]
+    else:
+        # Fallback: remove everything after _bold
+        prefix = stem.split("_bold")[0]
+
+    confounds_path = bold_path.parent / f"{prefix}_desc-confounds_timeseries.tsv"
+
+    df = pd.read_csv(confounds_path, sep="\t")
+    confounds = df.values.astype(np.float32)
+    # Handle NaN values (first row often has NaN for derivatives)
+    confounds = np.nan_to_num(confounds, nan=0.0)
+    columns = df.columns.tolist()
+
+    return confounds, columns
 
 
 MNI152_2MM_SHAPE = (91, 109, 91)


### PR DESCRIPTION
Main logic is in nisc.py so I would only need to make a small edit to every make_[dataset]_arrow.py for the other datasets if approved for abide

add fmriprep confounds to the hf Arrow datasets. Confounds are stored as:
- `confounds`: array of shape (n_timesteps, n_confounds) as Sequence(Sequence(float32))
- `confounds_columns`: list of column names for self-describing data

Changes:
- nisc.py: Add load_fmriprep_confounds() utility function
- make_abide_arrow.py: Load, resample, and store confounds alongside BOLD data