### PR TITLE
Fix SwiFT and NeuroSTORM to use LAS oriented data

### DIFF
--- a/src/fmri_fm_eval/models/swift.py
+++ b/src/fmri_fm_eval/models/swift.py
@@ -183,6 +183,10 @@ class SwiftTransform:
         volume[:, mask] = bold  # Assign flattened voxels to mask positions
         volume = rearrange(volume, "t z y x -> t x y z")
 
+        # flip x axis. the provided MNI data are in RAS orientation, but the model
+        # expects HCP (FSL) convention LAS.
+        volume = torch.flip(volume, (1,))
+
         # center crop or pad
         # fixed padding from original code for mni152 2mm volume
         # (91, 109, 91) -> (96, 96, 96)


### PR DESCRIPTION
SwiFT and NeuroSTORM don't seem to explicitly handle image orientation when reading MNI data. Both just extract the array data directly with nibabel. But, we can assume since they use HCP data which are preprocessed with FSL that they are using FSL convention LAS orientation. We are using RAS orientation (fMRIPrep convention) (see #38), so we need to flip the X axis for both models. Also made some minor changes to neurostorm and format.

cc @ckadirt 