### PR TITLE
Add Omni-fMRI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ neurostorm = [
     "wheel",
 ]
 
+omnifmri = [
+    "omnifmri",
+]
+
 [tool.setuptools_scm]
 version_file = "src/brainmarks/version.py"
 
@@ -91,6 +95,7 @@ brainlm = { git = "https://github.com/MedARC-AI/BrainLM.git", rev = "e287e0fa0f2
 brainharmonix = { git = "https://github.com/MedARC-AI/Brain-Harmony.git", rev = "5398f8f5540222973cf82d13ac1eb4c4b38af636" }
 brain-semantoks = { git = "https://github.com/SamGijsen/Brain-Semantoks.git", rev = "4b48b5942b2f7df60fe8aaf3f328733fad647b54" }
 neurostorm = { git = "https://github.com/MedARC-AI/NeuroSTORM.git", rev = "7fa3b96c8021735f1d84a81d0367b2568a2dc6e4"  }
+omnifmri = { git = "https://github.com/clane9/Omni-fMRI.git", rev = "aca9d2881c52a9e2329723d102e07985fe058162" }
 
 [tool.uv]
 no-build-isolation-package = ["mamba-ssm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ brainlm = { git = "https://github.com/MedARC-AI/BrainLM.git", rev = "e287e0fa0f2
 brainharmonix = { git = "https://github.com/MedARC-AI/Brain-Harmony.git", rev = "5398f8f5540222973cf82d13ac1eb4c4b38af636" }
 brain-semantoks = { git = "https://github.com/SamGijsen/Brain-Semantoks.git", rev = "4b48b5942b2f7df60fe8aaf3f328733fad647b54" }
 neurostorm = { git = "https://github.com/MedARC-AI/NeuroSTORM.git", rev = "7fa3b96c8021735f1d84a81d0367b2568a2dc6e4"  }
-omnifmri = { git = "https://github.com/clane9/Omni-fMRI.git", rev = "aca9d2881c52a9e2329723d102e07985fe058162" }
+omnifmri = { git = "https://github.com/MedARC-AI/Omni-fMRI.git", rev = "aca9d2881c52a9e2329723d102e07985fe058162" }
 
 [tool.uv]
 no-build-isolation-package = ["mamba-ssm"]

--- a/src/brainmarks/models/omnifmri.py
+++ b/src/brainmarks/models/omnifmri.py
@@ -1,0 +1,336 @@
+"""
+
+Omni-fMRI: A Universal Atlas-Free fMRI Foundation Model
+
+https://github.com/OneMore1/Omni-fMRI
+
+"""
+
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import templateflow.api as tflow
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from huggingface_hub import hf_hub_download
+from torch import Tensor
+
+from brainmarks import nisc
+from brainmarks.models.base import Embeddings
+from brainmarks.models.registry import register_model
+
+try:
+    from omnifmri.models.mae_model import AdaptiveMAE
+    from omnifmri.models.patch_embed_3d import TokenizedZeroConvPatchAttn3D
+
+except ImportError as exc:
+    raise ImportError(
+        "omnifmri not installed. Please install the optional omnifmri extra with `uv sync --extra omnifmri`"
+    ) from exc
+
+
+def fetch_omnifmri_checkpoint() -> Path:
+    ckpt_path = hf_hub_download(
+        repo_id="OneMore1/Omni-fMRI",
+        filename="checkpoint.pth",
+        revision="0bd3c34ba191e6ed9ac2a453b314f79178b7dfb2",
+    )
+    return Path(ckpt_path)
+
+
+# The following model-construction utils are copied verbatim from Omni-fMRI
+# extract_feat.py: https://github.com/OneMore1/Omni-fMRI/blob/main/extract_feat.py
+
+
+def as_3tuple(value: object) -> tuple[int, int, int]:
+    if isinstance(value, (list, tuple)):
+        if len(value) != 3:
+            raise ValueError(f"Expected a 3-item spatial tuple, got {value}")
+        return tuple(int(x) for x in value)
+    return (int(value), int(value), int(value))
+
+
+def create_model(config: dict) -> nn.Module:
+    model_config = config["model"]
+
+    return AdaptiveMAE(
+        img_size=as_3tuple(model_config["img_size"]),
+        patch_size=as_3tuple(model_config["patch_size"]),
+        in_chans=int(model_config["in_chans"]),
+        embed_dim=int(model_config["embed_dim"]),
+        depth=int(model_config["depth"]),
+        qkv_bias=bool(model_config["qkv_bias"]),
+        qk_norm=bool(model_config["qk_norm"]),
+        num_heads=int(model_config["num_heads"]),
+        decoder_embed_dim=int(model_config["decoder_embed_dim"]),
+        drop_path_rate=float(model_config["drop_path_rate"]),
+        decoder_depth=int(model_config["decoder_depth"]),
+        decoder_num_heads=int(model_config["decoder_num_heads"]),
+        mlp_ratio=float(model_config["mlp_ratio"]),
+        norm_layer=partial(nn.LayerNorm, eps=1e-6),
+        mask_ratio=float(model_config["mask_ratio"]),
+        mixed_patch_embed=TokenizedZeroConvPatchAttn3D,
+        patch_norm=bool(model_config["enable_patch_norm"]),
+        gate_attention=model_config["gate_attention"],
+    )
+
+
+def state_dict_from_checkpoint(checkpoint: object) -> dict:
+    if isinstance(checkpoint, dict):
+        if "model_state_dict" in checkpoint:
+            return checkpoint["model_state_dict"]
+        if "state_dict" in checkpoint:
+            return checkpoint["state_dict"]
+    if not isinstance(checkpoint, dict):
+        raise TypeError(f"Unsupported checkpoint type: {type(checkpoint)!r}")
+    return checkpoint
+
+
+def create_backbone(checkpoint: dict, config: dict, device: torch.device) -> nn.Module:
+    model = create_model(config)
+    state_dict = state_dict_from_checkpoint(checkpoint)
+    load_msg = model.load_state_dict(state_dict, strict=False)
+
+    unexpected = len(load_msg.unexpected_keys)
+    missing = len(load_msg.missing_keys)
+    print(
+        f"Loaded checkpoint weights with {missing} missing keys and {unexpected} unexpected keys."
+    )
+    if unexpected:
+        print("Unexpected keys are ignored by strict=False loading.")
+
+    if hasattr(model, "encoder"):
+        backbone = model.encoder
+    elif hasattr(model, "backbone"):
+        backbone = model.backbone
+    else:
+        backbone = model
+
+    backbone.to(device)
+    backbone.eval()
+    return backbone
+
+
+@torch.no_grad()
+def extract_tokens(backbone: nn.Module, sample: Tensor) -> tuple[Tensor, list[Tensor]]:
+    """
+    Copy of Omni-fMRI extract_feat.py `extract_tokens` with small change to support a
+    batch of samples.
+
+    Returns:
+        cls: (B, D) final-layer CLS token per item
+        patches: list of length B of (N_i, D) final-layer patch tokens
+    """
+    input_dict = backbone.patch_tokenizer(sample)
+    current_img_size = sample.shape[2:]
+
+    tokens, _, _, _, _ = backbone.mixed_patch(
+        sample,
+        backbone.pos_embed,
+        input_dict,
+        current_img_size=current_img_size,
+    )
+
+    seqlens = torch.as_tensor(input_dict["seqlens"], device=sample.device, dtype=torch.long)
+    arange = torch.arange(tokens.shape[1], device=sample.device).unsqueeze(0)
+    valid_mask = arange < seqlens.unsqueeze(1)
+
+    tokens_packed = tokens[valid_mask]
+    cu_seqlens = torch.cat(
+        [
+            torch.zeros(1, device=sample.device, dtype=torch.int32),
+            seqlens.cumsum(0, dtype=torch.int32),
+        ]
+    ).contiguous()
+    max_seqlen = int(seqlens.max().item())
+
+    layer_outputs = backbone.forward_features(
+        tokens_packed,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+    )
+    last_tokens = layer_outputs[-1]
+
+    # Unpack per-item sequences: [CLS, patch tokens...].
+    splits = torch.split(last_tokens, seqlens.tolist(), dim=0)
+    cls = torch.stack([seq[0] for seq in splits], dim=0)  # (M, D)
+    patches = [seq[1:] for seq in splits]  # list of (N_i, D)
+    return cls, patches
+
+
+class OmniFmriWrapper(nn.Module):
+    __space__: str = "mni"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        ckpt_path = fetch_omnifmri_checkpoint()
+        with torch.serialization.safe_globals(
+            [np._core.multiarray.scalar, np.dtype, np.dtypes.Float64DType]
+        ):
+            ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+
+        cfg = ckpt["config"]
+        self.backbone = create_backbone(ckpt, cfg, torch.device("cpu"))
+
+        # Model consumes a single 40-frame segment as `in_chans` (time-as-channels).
+        self.expected_seq_len = 40
+        self.max_windows = 8
+
+    def forward(self, batch: dict[str, Tensor]) -> Embeddings:
+        x = batch["bold"]
+        B, T, X, Y, Z = x.shape
+
+        # Split the temporal axis into non-overlapping windows, each fed to the model
+        # as a separate `in_chans`-frame volume (time-as-channels).
+        num_windows = min(T // self.expected_seq_len, self.max_windows)
+        T = num_windows * self.expected_seq_len
+        x = rearrange(x[:, :T], "b (w t) x y z -> (b w) t x y z", w=num_windows)
+
+        cls, patches = extract_tokens(self.backbone, x)
+        D = cls.shape[-1]
+
+        # Average CLS token over windows -> (B, 1, D).
+        cls_embeds = rearrange(cls, "(b w) d -> b w d", w=num_windows).mean(dim=1, keepdim=True)
+
+        # Concatenate patch tokens across windows for each sample.
+        per_sample = [
+            torch.cat(patches[b * num_windows : (b + 1) * num_windows], dim=0) for b in range(B)
+        ]
+
+        # Dynamic patching yields a variable patch count per sample; pad to the batch max,
+        # filling with each sample's mean token so mean-pooling stays unbiased.
+        max_len = max(p.shape[0] for p in per_sample)
+        patch_embeds = cls.new_zeros((B, max_len, D))
+        for b, p in enumerate(per_sample):
+            n = p.shape[0]
+            patch_embeds[b, :n] = p
+            if n < max_len:
+                patch_embeds[b, n:] = p.mean(dim=0, keepdim=True)
+
+        return Embeddings(cls_embeds=cls_embeds, reg_embeds=None, patch_embeds=patch_embeds)
+
+
+class OmniFmriTransform:
+    """
+    0. Unnormalize voxelwise z-scored data
+    1. temporal resampling to a uniform 0.72s TR
+    2. global z-score normalization over brain voxels
+    3. pad/crop to whole number of 40-frame windows
+    4. unmask input to full 4D MNI volume (background 0)
+    5. flip to LAS orientation
+    6. symmetric spatial crop/pad to (96, 96, 96)
+    7. reshape to (T, X, Y, Z)
+
+    https://github.com/OneMore1/Omni-fMRI/blob/main/data_preparation/preprocessing.py
+    """
+
+    def __init__(self, coord_normalize: bool = False):
+        self.coord_normalize = coord_normalize
+
+        # Mask calculation from brainmarks.readers (same MNI152 2mm space as NeuroSTORM).
+        roi_path = tflow.get(
+            "MNI152NLin6Asym", desc="brain", resolution=2, suffix="mask", extension="nii.gz"
+        )
+        mask = nisc.read_mni152_2mm_data(roi_path) > 0  # (Z, Y, X)
+
+        self.mask = torch.from_numpy(mask)
+        self.mask_shape = mask.shape
+
+        # Omni-fMRI input size is (in_chans, X, Y, Z) = (40, 96, 96, 96), time-as-channels.
+        self.expected_seq_len = 40
+        self.spatial_target = 96
+        self.max_windows = 8
+
+        # target temporal resampling. The paper resamples datasets with differing
+        # temporal resolutions to a uniform 0.72s TR (via cubic B-spline; we use linear
+        # interpolation for efficiency / consistency with the other models).
+        self.target_tr = 0.72
+
+    def __call__(self, sample: dict[str, Tensor]) -> dict[str, Tensor]:
+        """
+        Transform bold volumes to model input format.
+
+        sample dicts requires keys:
+            - bold: (T,V) normalized bold signal,
+            - mean: (1,V) mean of bold signal,
+            - std: (1,V) standard deviation of bold signal
+
+        sample dict is modified in place:
+            - bold: (T, X, Y, Z)
+
+        """
+        # unnormalize
+        if not self.coord_normalize:
+            bold = sample["bold"] * sample["std"] + sample["mean"]
+        else:
+            bold = sample["bold"]
+        tr = float(sample["tr"])
+
+        # temporal resampling to a uniform 0.72s TR.
+        # nb, we resample while in sparse (T, V) format for efficiency.
+        if abs(tr - self.target_tr) >= 0.1:
+            bold = resample_to_target_tr(bold, tr, self.target_tr)
+
+        # global normalization over the whole run.
+        # Omni z-scores non-zero (brain) voxels; here the sparse (T, V) form holds exactly
+        # the brain voxels, so global mean/std over `bold` is equivalent.
+        # https://github.com/OneMore1/Omni-fMRI/blob/main/data_preparation/preprocessing.py#L214
+        bold = (bold - bold.mean()) / (bold.std() + 1e-8)
+
+        # Pad if too short - repeat mean (consistent with other models)
+        T = len(bold)
+        if T < self.expected_seq_len:
+            mean = bold.mean(dim=0).repeat(self.expected_seq_len - T, 1)
+            bold = torch.cat([bold, mean], dim=0)
+            T = self.expected_seq_len
+
+        # Crop to a fixed number of non-overlapping windows
+        num_windows = min(T // self.expected_seq_len, self.max_windows)
+        T = num_windows * self.expected_seq_len
+        bold = bold[:T, :]
+
+        # unflatten to full volume; Omni z-scoring leaves the background at 0.
+        T, V = bold.shape
+        Z, Y, X = self.mask_shape
+        mask = self.mask.to(device=bold.device)
+        volume = torch.zeros((T, Z, Y, X), device=bold.device)
+        volume[:, mask] = bold
+        volume = rearrange(volume, "t z y x -> t x y z")
+
+        # flip x axis. the provided MNI data are in RAS orientation, but the model was
+        # trained on FSL MNI152 (LAS) data (cf. data_preparation/MNI152_T1_1mm_brain_mask.nii.gz).
+        volume = torch.flip(volume, (1,))
+
+        # symmetric center crop/pad to 96, following Omni normalize_spatial_dimensions
+        # (left = total // 2): x 91->96 pad(2,3), y 109->96 crop(6,7), z 91->96 pad(2,3).
+        # https://github.com/OneMore1/Omni-fMRI/blob/main/data_preparation/preprocessing.py#L126
+        assert (X, Y, Z) == (91, 109, 91), "unexpected volume shape"
+        # F.pad orders the trailing dims first: (z_l, z_r, y_l, y_r, x_l, x_r)
+        volume = F.pad(volume, (2, 3, -6, -7, 2, 3), value=0.0)
+
+        sample["bold"] = volume  # (T, X, Y, Z)
+        return sample
+
+
+def resample_to_target_tr(
+    x: Tensor,
+    tr: float,
+    target_tr: float,
+    mode: str = "linear",
+) -> Tensor:
+    # x: [T, D]
+    x = F.interpolate(
+        x.T.unsqueeze(0),
+        size=round(float(tr) * len(x) / float(target_tr)),
+        mode=mode,
+    )  # [1, D, T]
+    return x.squeeze(0).T
+
+
+@register_model
+def omnifmri(**kwargs) -> tuple[OmniFmriTransform, OmniFmriWrapper]:
+    return OmniFmriTransform(**kwargs), OmniFmriWrapper()

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,9 @@ neurostorm = [
     { name = "neurostorm" },
     { name = "wheel" },
 ]
+omnifmri = [
+    { name = "omnifmri" },
+]
 swift = [
     { name = "swiftfmri" },
 ]
@@ -587,6 +590,7 @@ requires-dist = [
     { name = "nilearn" },
     { name = "numpy" },
     { name = "omegaconf" },
+    { name = "omnifmri", marker = "extra == 'omnifmri'", git = "https://github.com/clane9/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162" },
     { name = "pandas" },
     { name = "peft" },
     { name = "pycortex" },
@@ -602,7 +606,7 @@ requires-dist = [
     { name = "wandb" },
     { name = "wheel", marker = "extra == 'neurostorm'" },
 ]
-provides-extras = ["brain-jepa", "swift", "brainlm", "brainharmonix", "brain-semantoks", "neurostorm"]
+provides-extras = ["brain-jepa", "swift", "brainlm", "brainharmonix", "brain-semantoks", "neurostorm", "omnifmri"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3333,6 +3337,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
+]
+
+[[package]]
+name = "omnifmri"
+version = "0.1.0"
+source = { git = "https://github.com/clane9/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162#aca9d2881c52a9e2329723d102e07985fe058162" }
+dependencies = [
+    { name = "einops" },
+    { name = "nibabel" },
+    { name = "numpy" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+
+[[package]]
+name = "opencv-python"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8a/b04776ec45d2dea08a1b176f1829201db3515d4ed16c35f8fcc9fa7beb16/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2b4272e736836f66c2d176e43ab8101f3a00d45654916399f52e150c58981ac", size = 50614064, upload-time = "2026-07-02T06:53:22.604Z" },
+    { url = "https://files.pythonhosted.org/packages/95/54/eb47866b94f2b5b42dde17644b78055ef1ee05aae59962c7290e55270803/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8b6d0a212253dd26ad338c812f1f23ca118fdf05a9c8c6b9444f161aa8c5881", size = 71064711, upload-time = "2026-07-02T06:54:13.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/da/962579f1e703cbf8c5422fd1f576467dcb3b5b0b0b81c1471c979764353a/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:08d5d91d967b58d6db86073b2ad3eaef88ca4ebdfd45c9059bf59f5ded0c7ad2", size = 49798576, upload-time = "2026-07-02T06:54:33.781Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4c/c73f828fdbcd37eaf21d08fa852544a3ca7c2dbb3ea76873d64f2ea413d1/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8de2dec111122a02e8beb28e16c31904992dfd6186560b142a92c71403c1039", size = 73783032, upload-time = "2026-07-02T06:55:03.415Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4b/edaf83b996ca5a1a3d8ccad485706b9c6d4742b13b9c4586bf1c1e7d9423/opencv_python-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:4b4b1a34c79bf8d3738e3cfe9a9e67b51a79663f6b692cbdad8c31f570da4157", size = 35564734, upload-time = "2026-07-02T05:49:57.704Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f0/9fa6e85cb10c8eb36a0222d27e50fe381b86ce49a55446bf39f491727564/opencv_python-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:f90ba04b8f73bc5c3814037699739f0156f597338a98f05956c684e7c3ca10d2", size = 44000345, upload-time = "2026-07-02T05:49:54.971Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ requires-dist = [
     { name = "nilearn" },
     { name = "numpy" },
     { name = "omegaconf" },
-    { name = "omnifmri", marker = "extra == 'omnifmri'", git = "https://github.com/clane9/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162" },
+    { name = "omnifmri", marker = "extra == 'omnifmri'", git = "https://github.com/MedARC-AI/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162" },
     { name = "pandas" },
     { name = "peft" },
     { name = "pycortex" },
@@ -3342,7 +3342,7 @@ wheels = [
 [[package]]
 name = "omnifmri"
 version = "0.1.0"
-source = { git = "https://github.com/clane9/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162#aca9d2881c52a9e2329723d102e07985fe058162" }
+source = { git = "https://github.com/MedARC-AI/Omni-fMRI.git?rev=aca9d2881c52a9e2329723d102e07985fe058162#aca9d2881c52a9e2329723d102e07985fe058162" }
 dependencies = [
     { name = "einops" },
     { name = "nibabel" },


### PR DESCRIPTION
Add model inference wrapper for [Omni-fMRI](https://arxiv.org/abs/2601.23090).

Benchmark performance:

| model       |   ABIDE Dx |   ADHD200 Dx |    ADNI Dx |    PPMI Dx |   AABC Age |   AABC Sex |   HCP-YA Task21 |   NSD COCO24 |
|:------------|-----------:|-------------:|-----------:|-----------:|-----------:|-----------:|----------------:|-------------:|
| Omni-fMRI   |         54 |         60.2 |       70.7 |       56.9 |       52.5 |       86.5 |     21.1 (85.1) |   6.3 (12.9) |
| NeuroSTORM  |       53.5 |         61.1 |       66.8 |       53.4 |       56.6 |       82.7 |     17.5 (70.5) |   6.4 (12.2) |
| CortexMAE-V | 60.4 ± 0.8 |   58.8 ± 1.1 | 64.3 ± 1.6 | 59.1 ± 1.2 | 53.4 ± 0.5 | 86.3 ± 0.7 |      96.2 ± 0.3 |   27.7 ± 0.7 |

The reported scores use the model's default preprocessing pipeline. The improved scores on HCP-YA Task21 and NSD COCO24 (in parentheses) use the voxel normalization correction at evaluation time.